### PR TITLE
Clarify `.error()` docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,7 +233,7 @@ Message to be shown upon failure.
 
 ### .error(error, message)
 
-Assert that `error` is `false` with an optional description message.
+Assert that `error` is falsy with an optional description message.
 
 #### error
 


### PR DESCRIPTION
`.error()` checks if a value is falsy, but that shouldn't really be `false`.
